### PR TITLE
Publish docker images for releases with goreleaser

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,22 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -26,4 +37,5 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,9 +62,3 @@ checksum:
   name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
-changelog:
-  sort: asc
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,6 +58,10 @@ docker_manifests:
     image_templates:
       - "{{ .Env.DOCKERHUB_USERNAME }}/{{ .ProjectName }}:{{ .Version }}-amd64"
       - "{{ .Env.DOCKERHUB_USERNAME }}/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+  - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/{{ .ProjectName }}:latest"
+    image_templates:
+      - "{{ .Env.DOCKERHUB_USERNAME }}/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKERHUB_USERNAME }}/{{ .ProjectName }}:{{ .Version }}-arm64v8"
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,42 @@ archives:
       - README.md
       - LICENSE
       - example/**
+dockers:
+  - goos: linux
+    goarch: amd64
+    image_templates:
+      - "{{ .Env.DOCKERHUB_USERNAME }}/{{ .ProjectName }}:{{ .Tag }}-amd64"
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.url=https://github.com/aspettl/{{ .ProjectName }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aspettl/{{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+  - goos: linux
+    goarch: arm64
+    image_templates:
+      - "{{ .Env.DOCKERHUB_USERNAME }}/{{ .ProjectName }}:{{ .Tag }}-arm64v8"
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.url=https://github.com/aspettl/{{ .ProjectName }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aspettl/{{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+docker_manifests:
+  - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/{{ .ProjectName }}:{{ .Version }}"
+    image_templates:
+      - "{{ .Env.DOCKERHUB_USERNAME }}/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKERHUB_USERNAME }}/{{ .ProjectName }}:{{ .Version }}-arm64v8"
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ ADD . /go/src/app
 
 RUN go get -d -v ./...
 
-RUN go build -o /go/bin/ccliwrapper
+RUN CGO_ENABLED=0 go build -o /go/bin/ccliwrapper
 
-FROM gcr.io/distroless/base-debian11
+FROM scratch
 
 COPY --from=build /go/bin/ccliwrapper /
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,5 @@
+FROM scratch
+
+COPY ccliwrapper /
+
+ENTRYPOINT ["/ccliwrapper"]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ are mounted.
 
 For the example config in this repo use (with `podman`):
 
-    podman run --rm -v $PWD/example:/example docker.io/aspettl/ccliwrapper:edge generate --config /example/ccliwrapper.yaml
+    podman run --rm -v $PWD/example:/example docker.io/aspettl/ccliwrapper:latest generate --config /example/ccliwrapper.yaml
 
 Note: `ccliwrapper` tries to create folders listed in the config file for mounts (and
 prints a warning if it does so). The simple reason is that a `run` command fails when


### PR DESCRIPTION
* use same binary for docker image
* multi-arch (amd64 and arm64)
* use `CGO_ENABLED=0` also for edge/nightly builds with docker (and switch to empty scratch base image instead of distroless)